### PR TITLE
Convert commands to support multiple codes

### DIFF
--- a/powerbot.go
+++ b/powerbot.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 )
 
 func (bot *Bot) WriteCode(code int) error {
@@ -74,6 +75,7 @@ func (bot *Bot) ParseAndReply(channel string, msg string, user string) {
 			} else {
 				failed_codes[code] = write_err
 			}
+			time.Sleep(time.Second)
 		}
 		reply := fmt.Sprintf("Sent out codes %v for %v.", successful_codes, command)
 		for code, write_err := range failed_codes {

--- a/powerbot.yaml
+++ b/powerbot.yaml
@@ -11,5 +11,5 @@ channels:
  - "#test2"
 
 commands:
-  "christmas on": 5330371
-  "christmas off": 5330380
+  "christmas on": [5330371, 5330372]
+  "christmas off": [5330380]


### PR DESCRIPTION
I'd make commands support either an int or a list in the yaml,
but then I'd have to mess with golang's type reflection.

Does there need to be a delay between sending codes as to not
upset the radio?